### PR TITLE
Git and GitHub Basics Course Project: Added launch file cRpxS9u5 with a pink X-shaped racetrack

### DIFF
--- a/launch/race-track-cRpxS9u5.launch
+++ b/launch/race-track-cRpxS9u5.launch
@@ -1,0 +1,33 @@
+<launch>
+  <node pkg="tf2_ros" type="static_transform_publisher" name="map_odom" args="0 0 0 0 0 0 map odom" /> 
+  <arg name="h" value="header: {frame_id: 'map', seq: 0, stamp: {nsecs: 0, secs: 0}}" />
+  <arg name="orientation" value="orientation: {w: 1.0, x: 0.0, y: 0.0, z: 0.0}" />
+  <arg name="scale" value="scale: {x: 0.2, y: 0.2, z: 0.2}" />
+  <arg name="color" value="color: {a: 1.0, b: 1.0, g: 0.3, r: 1.0}"/>
+  <arg name="position" value="position: {x: 0.0, y: 0.0, z: 0.0}"/>
+  <arg name="pose" value="pose: {$(arg orientation), $(arg position)}"/>
+  <arg name="lt" value="lifetime: {nsecs: 0, secs: 0}"/>
+  <!-- start of race track coordinates -->
+  <arg name="p1" value="{x: 1.0, y: 2.0, z: 0.0}"/>
+  <arg name="p2" value="{x: 4.0, y: 5.0, z: 0.0}"/>
+  <arg name="p3" value="{x: 1.0, y: 8.0, z: 0.0}"/>
+  <arg name="p4" value="{x: 2.0, y: 9.0, z: 0.0}"/>
+  <arg name="p5" value="{x: 5.0, y: 6.0, z: 0.0}"/>
+  <arg name="p6" value="{x: 8.0, y: 9.0, z: 0.0}"/>
+  <arg name="p7" value="{x: 9.0, y: 8.0, z: 0.0}"/>
+  <arg name="p8" value="{x: 6.0, y: 5.0, z: 0.0}"/>
+  <arg name="p9" value="{x: 9.0, y: 2.0, z: 0.0}"/>
+  <arg name="p10" value="{x: 8.0, y: 1.0, z: 0.0}"/>
+  <arg name="p11" value="{x: 5.0, y: 4.0, z: 0.0}"/>
+  <arg name="p12" value="{x: 2.0, y: 1.0, z: 0.0}"/>
+  <arg name="p13" value="{x: 1.0, y: 2.0, z: 0.0}"/>
+  <!-- end of race track coordinates -->
+
+  <!-- list of points that draw the racetrack -->
+  <arg name="pts" value="points: [$(arg p1),$(arg p2),$(arg p3),$(arg p4),$(arg p5),$(arg p6),$(arg p7),$(arg p8),$(arg p9),$(arg p10),$(arg p11),$(arg p12),$(arg p13)]"/>  
+  
+  <arg name="marker" value="'{$(arg h), ns: 'MWS', id: 0, type: 4, action: 0, $(arg pose), $(arg scale), $(arg color), $(arg lt), $(arg pts)}'" />
+  <node name="pub1" pkg="rostopic" type="rostopic" args="pub /shape visualization_msgs/Marker $(arg marker)"/>
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find virtual_racetracks_collection)/config/racetrack.rviz"/>
+
+</launch>


### PR DESCRIPTION
This pull request is for the completion of Section 5.6 ("Tasks - Part 4") of the Git and Github Basics Course in The Construct. This request will add a new launch file titled "race-track-cRpxS9u5.launch" to the original repository. This launch file produces a light pink racetrack in the shape of a large "X".

Producing the "X" shape is a simple, clean shape that uses positions in all four quadrants of the visible grid. It also uses points close to the center of the grid and close to the corners of the grid. Finally, it's a vibrant, bright pink that uses red, green, and blue values for its color. The execution is simple and bright, but I think that makes it unique!

<img width="994" alt="Git_and_Github_Basics_Course_Project" src="https://github.com/user-attachments/assets/59a2819b-a8e2-4684-9ead-46feb29f34f0">
